### PR TITLE
fix: initial dimensions large enough to avoid foundry warning

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -75,11 +75,11 @@
 				"center": true,
 				"fileDropEnabled": false,
 				"fullscreen": false,
-				"height": 650,
+				"height": 700,
 				"resizable": true,
 				"title": "FLC",
 				"userAgent": "FLC",
-				"width": 900
+				"width": 1024
 			}
 		]
 	}


### PR DESCRIPTION
 Minor user experience touch-up. Foundry displays a warning about screen size for display resolutions below 1024x700, might as well not trigger it.