### PR TITLE
Fix High Sev CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@fontsource-variable/inter": "^5.0.16",
 				"@fontsource-variable/jetbrains-mono": "^5.0.19",
 				"@sveltejs/adapter-static": "^3.0.1",
-				"@sveltejs/kit": "^2.0.6",
+				"@sveltejs/kit": "^2.4.3",
 				"@sveltejs/vite-plugin-svelte": "^3.0.1",
 				"@tauri-apps/api": "^2.0.0-alpha.13",
 				"@tauri-apps/cli": "^2.0.0-alpha.20",
@@ -995,9 +995,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.0.6.tgz",
-			"integrity": "sha512-dnHtyjBLGXx+hrZQ9GuqLlSfTBixewJaByUVWai7LmB4dgV3FwkK155OltEgONDQW6KW64hLNS/uojdx3uC2/g==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.4.3.tgz",
+			"integrity": "sha512-nKNhUdt61vtD961kQpUk6vLDhpnV0yku5F1uYNWvrJYFV0+cGfmW7ol0JVMSjHMXlMtmmv2FTc+nPRrTFwb2UA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -1005,6 +1005,7 @@
 				"cookie": "^0.6.0",
 				"devalue": "^4.3.2",
 				"esm-env": "^1.0.0",
+				"import-meta-resolve": "^4.0.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
@@ -2785,6 +2786,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+			"integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/imurmurhash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "flc",
-	"version": "4.3.1",
+	"version": "4.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "flc",
-			"version": "4.3.1",
+			"version": "4.5.0",
 			"devDependencies": {
 				"@fontsource-variable/inter": "^5.0.16",
 				"@fontsource-variable/jetbrains-mono": "^5.0.19",
@@ -41,7 +41,7 @@
 				"tailwindcss": "^3.4.0",
 				"tslib": "^2.6.2",
 				"typescript": "^5.3.3",
-				"vite": "^5.0.10",
+				"vite": "^5.0.12",
 				"zod": "^3.22.4"
 			}
 		},
@@ -4605,9 +4605,9 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
-			"integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+			"integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@fontsource-variable/inter": "^5.0.16",
 		"@fontsource-variable/jetbrains-mono": "^5.0.19",
 		"@sveltejs/adapter-static": "^3.0.1",
-		"@sveltejs/kit": "^2.0.6",
+		"@sveltejs/kit": "^2.4.3",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@tauri-apps/api": "^2.0.0-alpha.13",
 		"@tauri-apps/cli": "^2.0.0-alpha.20",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"tailwindcss": "^3.4.0",
 		"tslib": "^2.6.2",
 		"typescript": "^5.3.3",
-		"vite": "^5.0.10",
+		"vite": "^5.0.12",
 		"zod": "^3.22.4"
 	},
 	"type": "module"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1615,7 +1615,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.10",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",


### PR DESCRIPTION
Vite - CVE-2024-23331 - 7.5/10
Svelte - CVE-2024-23641 - 7.5/10

Last one is this for Hyperium
```
An attacker with an HTTP/2 connection to an affected endpoint can send a steady stream of invalid frames to force the
generation of reset frames on the victim endpoint.
By closing their recv window, the attacker could then force these resets to be queued in an unbounded fashion,
resulting in Out Of Memory (OOM) and high CPU usage.

This fix is corrected in https://github.com/hyperium/h2/pull/737, which limits the total number of
internal error resets emitted by default before the connection is closed.
```